### PR TITLE
Fix -crash_retry argument

### DIFF
--- a/fuzzer.cpp
+++ b/fuzzer.cpp
@@ -252,12 +252,14 @@ RunResult Fuzzer::RunSampleAndGetCoverage(ThreadContext *tc, Sample *sample, Cov
   // save crashes and hangs immediately when they are detected
   if (result == CRASH) {
     string crash_desc = tc->instrumentation->GetCrashName();
-
-    if (crash_reproduce_retries > 0 && TryReproduceCrash(tc, sample, init_timeout, timeout) == CRASH) {
-      // get a hopefully better name
-      crash_desc = tc->instrumentation->GetCrashName();
-    } else {
-      crash_desc = "flaky_" + crash_desc;
+    
+    if (crash_reproduce_retries > 0) {
+        if (TryReproduceCrash(tc, sample, init_timeout, timeout) == CRASH) {
+            // get a hopefully better name
+            crash_desc = tc->instrumentation->GetCrashName();
+        } else {
+            crash_desc = "flaky_" + crash_desc;
+        }
     }
     
     bool should_save_crash = false;

--- a/fuzzer.cpp
+++ b/fuzzer.cpp
@@ -253,7 +253,7 @@ RunResult Fuzzer::RunSampleAndGetCoverage(ThreadContext *tc, Sample *sample, Cov
   if (result == CRASH) {
     string crash_desc = tc->instrumentation->GetCrashName();
 
-    if (TryReproduceCrash(tc, sample, init_timeout, timeout) == CRASH) {
+    if (crash_reproduce_retries > 0 && TryReproduceCrash(tc, sample, init_timeout, timeout) == CRASH) {
       // get a hopefully better name
       crash_desc = tc->instrumentation->GetCrashName();
     } else {


### PR DESCRIPTION
The code doesn't account for command-line argument "-crash_retry 0". 
If provided, this argument will, upon finding a crash, cause a "Run-Time Check Failure 3 - The variable 'result' is being used without being initialized."
This is an uncommon usecase, but I have encountered this while fuzzing a binary that keeps a handle to the crashing file for a bit too long. 
Using "-crash_retry 0" allows for fuzzing the binary, albeit flaky fuzzing.