### PR TITLE
Add Support for fuzzing by attaching to running processes on Windows. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ The following command line arguments are supported:
 
 `-dict <path>` - Provides a dictionary to be used during mutation. The dictionary should be a text file with every entry on a separate line. `\xXX` escape sequences can be used.
 
+`-process-name <name of running process> - Enables fuzzing for processes that are already running in the operating system such as Windows services. The fuzzer will attach to the specified running process and get coverage from there. Then, the script specified after `--` will be opened in a new thread and will send the current testcase to running process. Note: this mode only allows for one thread and file delivery through the script. 
+
 For TinyInst instrumentation command line arguments, refer to [TinyInst readme](https://github.com/googleprojectzero/TinyInst).
 
 Example (macOS):

--- a/fuzzer.cpp
+++ b/fuzzer.cpp
@@ -113,13 +113,10 @@ void Fuzzer::ParseOptions(int argc, char **argv) {
   incremental_coverage = GetBinaryOption("-incremental_coverage", argc, argv, true);
   
   add_all_inputs = GetBinaryOption("-add_all_inputs", argc, argv, false);
-
+  
   process_name = GetOption("-process_name", argc, argv);
 
-  attach_mode = false;
-  
   if (process_name != NULL) {
-    attach_mode = true;
     //set threads to one as multiple threads attaching to one process does not work well
     num_threads = 1;
   }
@@ -255,13 +252,7 @@ RunResult Fuzzer::RunSampleAndGetCoverage(ThreadContext *tc, Sample *sample, Cov
       FATAL("Repeatedly failed to deliver sample");
     }
   }
-  RunResult result;
-  if (attach_mode) {
-     script = ArgvToCmd(tc->target_argc, tc->target_argv);
-     result = tc->instrumentation->Attach(script, process_name, init_timeout, timeout);
-  } else {
-     result = tc->instrumentation->Run(tc->target_argc, tc->target_argv, init_timeout, timeout);
-  }
+  RunResult result = tc->instrumentation->Run(tc->target_argc, tc->target_argv, init_timeout, timeout);
 
   tc->instrumentation->GetCoverage(*coverage, true);
 
@@ -341,12 +332,9 @@ RunResult Fuzzer::TryReproduceCrash(ThreadContext* tc, Sample* sample, uint32_t 
         FATAL("Repeatedly failed to deliver sample");
       }
     }
-    if (attach_mode) {
-      script = ArgvToCmd(tc->target_argc, tc->target_argv);
-      result = tc->instrumentation->AttachWithCrashAnalysis(script, process_name, init_timeout, timeout);
-    } else {
-      result = tc->instrumentation->RunWithCrashAnalysis(tc->target_argc, tc->target_argv, init_timeout, timeout);
-    }
+    
+    result = tc->instrumentation->RunWithCrashAnalysis(tc->target_argc, tc->target_argv, init_timeout, timeout);
+    
     tc->instrumentation->ClearCoverage();
 
     if (result == CRASH) return result;
@@ -429,8 +417,8 @@ RunResult Fuzzer::RunSample(ThreadContext *tc, Sample *sample, int *has_new_cove
     if(new_thread_coverage.empty()) return result;
   }
   
-  //printf("found new coverage: \n");
-  //PrintCoverage(initialCoverage);
+  // printf("found new coverage: \n");
+  // PrintCoverage(initialCoverage);
 
   // the sample returned new coverage
 

--- a/fuzzer.h
+++ b/fuzzer.h
@@ -196,6 +196,10 @@ protected:
   uint64_t num_samples_discarded;
   uint64_t num_threads;
   uint64_t total_execs;
+
+  bool attach_mode;
+  char * script;
+  char * process_name;
   
   void SaveState(ThreadContext *tc);
   void RestoreState(ThreadContext *tc);

--- a/fuzzer.h
+++ b/fuzzer.h
@@ -197,8 +197,6 @@ protected:
   uint64_t num_threads;
   uint64_t total_execs;
 
-  bool attach_mode;
-  char * script;
   char * process_name;
   
   void SaveState(ThreadContext *tc);

--- a/instrumentation.h
+++ b/instrumentation.h
@@ -31,12 +31,6 @@ public:
   virtual RunResult RunWithCrashAnalysis(int argc, char** argv, uint32_t init_timeout, uint32_t timeout) {
     return Run(argc, argv, init_timeout, timeout);
   }
-
-  virtual RunResult Attach(char * script, char * process_name, uint32_t init_timeout, uint32_t timeout) = 0;
-  
-  virtual RunResult AttachWithCrashAnalysis(char * script, char * process_name, uint32_t init_timeout, uint32_t timeout) {
-    return Attach(script, process_name, init_timeout, timeout);
-  }
   
   virtual void CleanTarget() = 0;
 

--- a/instrumentation.h
+++ b/instrumentation.h
@@ -32,6 +32,12 @@ public:
     return Run(argc, argv, init_timeout, timeout);
   }
 
+  virtual RunResult Attach(char * script, char * process_name, uint32_t init_timeout, uint32_t timeout) = 0;
+  
+  virtual RunResult AttachWithCrashAnalysis(char * script, char * process_name, uint32_t init_timeout, uint32_t timeout) {
+    return Attach(script, process_name, init_timeout, timeout);
+  }
+  
   virtual void CleanTarget() = 0;
 
   virtual bool HasNewCoverage() = 0;

--- a/tinyinstinstrumentation.cpp
+++ b/tinyinstinstrumentation.cpp
@@ -22,7 +22,6 @@ limitations under the License.
 
 #include <sstream>
 
-
 void TinyInstInstrumentation::Init(int argc, char **argv) {
   instrumentation = new LiteCov();
   instrumentation->Init(argc, argv);
@@ -131,6 +130,117 @@ RunResult TinyInstInstrumentation::RunWithCrashAnalysis(int argc, char** argv, u
   // disable instrumentation when reproducing crashes
   instrumentation->DisableInstrumentation();
   RunResult ret = Run(argc, argv, init_timeout, timeout);
+  instrumentation->Kill();
+  instrumentation->EnableInstrumentation();
+  return ret;
+}
+
+RunResult TinyInstInstrumentation::Attach(char * script, char * process_name, uint32_t init_timeout, uint32_t timeout) {
+  DebuggerStatus status;
+  RunResult ret = OTHER_ERROR;
+
+  if (instrumentation->IsTargetFunctionDefined()) {
+    if (cur_iteration == num_iterations) {
+      instrumentation->Kill();
+      cur_iteration = 0;
+    }
+  }
+  
+  // else clear only when the target function is reached
+  if (!instrumentation->IsTargetFunctionDefined()) {
+    instrumentation->ClearCoverage();
+  }
+
+  uint32_t timeout1 = timeout;
+  if (instrumentation->IsTargetFunctionDefined()) {
+    timeout1 = init_timeout;
+  }
+
+  if (instrumentation->IsTargetAlive() && persist) {
+    status = instrumentation->Continue(timeout1);
+  } else {
+    instrumentation->Kill();
+    cur_iteration = 0;
+    instrumentation->script = script;
+    Sleep(init_timeout);
+    processID = FindProcessId(process_name);
+    status = instrumentation->Attach(processID, timeout1);
+  }
+
+  // if target function is defined,
+  // we should wait until it is hit
+  if (instrumentation->IsTargetFunctionDefined()) {
+    if (status != DEBUGGER_TARGET_START) {
+      // try again with a clean process
+      WARN("Target function not reached, retrying with a clean process\n");
+      instrumentation->Kill();
+      cur_iteration = 0;
+      instrumentation->script = script;
+      Sleep(init_timeout);
+      processID = FindProcessId(process_name);
+      status = instrumentation->Attach(processID, timeout1);
+    }
+
+    if (status != DEBUGGER_TARGET_START) {
+      switch (status) {
+      case DEBUGGER_CRASHED:
+        FATAL("Process crashed before reaching the target method\n");
+        break;
+      case DEBUGGER_HANGED:
+        FATAL("Process hanged before reaching the target method\n");
+        break;
+      case DEBUGGER_PROCESS_EXIT:
+        FATAL("Process exited before reaching the target method\n");
+        break;
+      default:
+        FATAL("An unknown problem occured before reaching the target method\n");
+        break;
+      }
+    }
+
+    instrumentation->ClearCoverage();
+
+    status = instrumentation->Continue(timeout);
+  }
+
+  switch (status) {
+  case DEBUGGER_CRASHED:
+    ret = CRASH;
+    instrumentation->Kill();
+    break;
+  case DEBUGGER_HANGED:
+    ret = HANG;
+    instrumentation->Kill();
+    break;
+  case DEBUGGER_PROCESS_EXIT:
+    ret = OK;
+    if (instrumentation->IsTargetFunctionDefined()) {
+      WARN("Process exit during target function\n");
+      ret = HANG;
+    }
+    break;
+  case DEBUGGER_TARGET_END:
+    if (instrumentation->IsTargetFunctionDefined()) {
+      ret = OK;
+      cur_iteration++;
+    } else {
+      FATAL("Unexpected status received from the debugger\n");
+    }
+    break;
+  default:
+    FATAL("Unexpected status received from the debugger\n");
+    break;
+  }
+
+  return ret;
+}
+
+RunResult TinyInstInstrumentation::AttachWithCrashAnalysis(char * script, char * process_name, uint32_t init_timeout, uint32_t timeout) {
+  // clean process when reproducing crashes
+  instrumentation->Kill();
+  // disable instrumentation when reproducing crashes
+  instrumentation->DisableInstrumentation();
+  RunResult ret = Attach(script, process_name, init_timeout, timeout);
   instrumentation->Kill();
   instrumentation->EnableInstrumentation();
   return ret;

--- a/tinyinstinstrumentation.h
+++ b/tinyinstinstrumentation.h
@@ -32,9 +32,6 @@ public:
 
   RunResult Run(int argc, char** argv, uint32_t init_timeout, uint32_t timeout) override;
   RunResult RunWithCrashAnalysis(int argc, char** argv, uint32_t init_timeout, uint32_t timeout) override;
-
-  RunResult TinyInstInstrumentation::Attach(char * script, char * process_name, uint32_t init_timeout, uint32_t timeout) override;
-  RunResult TinyInstInstrumentation::AttachWithCrashAnalysis(char * script, char * process_name, uint32_t init_timeout, uint32_t timeout) override;
   
   void CleanTarget() override;
 
@@ -50,7 +47,10 @@ public:
 protected:
   LiteCov * instrumentation;
   bool persist;
+  boolean attach_mode;
   int processID;
+  char * process_name;
+  char * script;
   int num_iterations;
   int cur_iteration;
 };

--- a/tinyinstinstrumentation.h
+++ b/tinyinstinstrumentation.h
@@ -33,6 +33,9 @@ public:
   RunResult Run(int argc, char** argv, uint32_t init_timeout, uint32_t timeout) override;
   RunResult RunWithCrashAnalysis(int argc, char** argv, uint32_t init_timeout, uint32_t timeout) override;
 
+  RunResult TinyInstInstrumentation::Attach(char * script, char * process_name, uint32_t init_timeout, uint32_t timeout) override;
+  RunResult TinyInstInstrumentation::AttachWithCrashAnalysis(char * script, char * process_name, uint32_t init_timeout, uint32_t timeout) override;
+  
   void CleanTarget() override;
 
   bool HasNewCoverage() override;
@@ -47,6 +50,7 @@ public:
 protected:
   LiteCov * instrumentation;
   bool persist;
+  int processID;
   int num_iterations;
   int cur_iteration;
 };


### PR DESCRIPTION
I have made some changes to Jackalope that allow someone to fuzz processes that are already running on the system by attaching to them. The current limitations of this new mode are that it only supports file delivery and single threads. The reason for only supporting one thread is that attaching multiple threads to the same process to fuzz results in unreliable. I also plan to add a recovery_script option to this mode which allows the user to specify a script that can be used to restart the running process to a fresh state. Currently, I have tested this mode on processes that have an automatic restart feature after each time they are killed, so I didn't need the recovery_script option. Please let me know if you have any questions or concerns about my commit. 

To support this new mode, I needed to make some minor changes to TinyInst as well. Those changes are in a separate [pull request](https://github.com/googleprojectzero/TinyInst/pull/61) on that repository. 