### PR TITLE
[Bugfix] Removing redundant and problematic sample saving code

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -148,7 +148,7 @@ int CoverageClient::ReportCrash(Sample *crash, std::string &crash_desc) {
 
 int CoverageClient::ReportNewCoverage(Coverage *new_coverage, Sample *new_sample) {
   ConnectToServer('S');
-  
+
   SendCoverage(sock, *new_coverage);
 
   char reply;
@@ -206,18 +206,6 @@ int CoverageClient::GetUpdates(std::list<Sample *> &new_samples, uint64_t total_
         return 0;
       }
 
-      if (!keep_samples_in_memory) {
-        char fileindex[20];
-        sprintf(fileindex, "%05lld", num_samples);
-        string filename = string("sample_") + fileindex;
-        string outfile = DirJoin(sample_dir, filename);
-        sample->filename = outfile;
-        sample->Save();
-        sample->FreeMemory();
-
-        num_samples++;
-      }
-
       new_samples.push_back(sample);
     } else {
       DisconnectFromServer();
@@ -234,12 +222,9 @@ int CoverageClient::GetUpdates(std::list<Sample *> &new_samples, uint64_t total_
 void CoverageClient::SaveState(FILE* fp) {
   fwrite(&last_timestamp, sizeof(last_timestamp), 1, fp);
   fwrite(&client_id, sizeof(last_timestamp), 1, fp);
-  fwrite(&num_samples, sizeof(last_timestamp), 1, fp);
 }
 
 void CoverageClient::LoadState(FILE* fp) {
   fread(&last_timestamp, sizeof(last_timestamp), 1, fp);
   fread(&client_id, sizeof(last_timestamp), 1, fp);
-  fread(&num_samples, sizeof(last_timestamp), 1, fp);
 }
-

--- a/client.h
+++ b/client.h
@@ -24,8 +24,8 @@ limitations under the License.
 
 class CoverageClient : public ServerCommon {
 public:
-  CoverageClient() : last_timestamp(0), num_samples(0),
-    have_server(false), server_port(DEFAULT_SERVER_PORT)
+  CoverageClient() : last_timestamp(0), have_server(false),
+    server_port(DEFAULT_SERVER_PORT)
   {
     PRNG::SecureRandom(&client_id, sizeof(client_id));
   }
@@ -47,7 +47,6 @@ private:
 
   uint64_t last_timestamp;
   uint64_t client_id;
-  uint64_t num_samples;
 
   std::string server_ip;
   uint16_t server_port;


### PR DESCRIPTION
There is a bug in how downloading samples from a server is implemented.

First of all, saving the sample in client.cpp is redundant. The new samples received from the server are being returned back to fuzzer.cpp in server_samples. Then process sample jobs are created here:
https://github.com/googleprojectzero/Jackalope/blob/69c4eee961102593cdf75bd81a7c99da805266e3/fuzzer.cpp#L666-L674

Then, Fuzzer::ProcessSample calls RunSample which analyzes the coverage, and saves the sample if it produces new coverage. (Fuzzer::ProcessSample saves the sample if it does not produce new coverage but add_all_inputs is specified)
https://github.com/googleprojectzero/Jackalope/blob/69c4eee961102593cdf75bd81a7c99da805266e3/fuzzer.cpp#L766-L777

RunSample saves the sample here:
https://github.com/googleprojectzero/Jackalope/blob/69c4eee961102593cdf75bd81a7c99da805266e3/fuzzer.cpp#L455-L469

Therefore, we don't need to save samples in client.cpp.

Not only this code is redundant, but there is also a serious problem which leads to samples being overwritten on disk. 
In both cases, `num_samples` is being used to generate the file name. But those are 2 different private variables in CoverageClient and Fuzzer classes. Those values are not synchronized. Fuzzer increments that variable when a new sample that improves the coverage is found, while CoverageClient increments it when it receives new coverage from the server. In both cases, the files are saved to the same directory.

Imagine the fuzzer finds a sample generating new coverage and saves it as `sample_00001`. Next, the server reports new coverage, and the client downloads the new sample from  the server, which it also saves as `sample_00001`, overwriting the initial file. Then the client processes the new sample and (if it generates new coverage) saves the same sample as `sample_00002`. 

Note, this change will make previous saved client states incompatible, due to `num_samples` being removed from the save file. It is probably not a big deal, but I can add code to handle that case if we want to keep it.