### PR TITLE
Add macOS audio fuzzing example.

### DIFF
--- a/examples/AudioCodecs/README.md
+++ b/examples/AudioCodecs/README.md
@@ -1,0 +1,39 @@
+## Apple audio decoder fuzzing example
+
+In January 2025, Apple fixed 3 vulnerabilities in audio decoding modules in macOS Sonoma found using Jackalope. 
+
+```
+CoreAudio
+Available for: macOS Sequoia
+
+Impact: Parsing a file may lead to an unexpected app termination
+Description: The issue was addressed with improved checks.
+
+CVE-2025-24160: Google Threat Analysis Group
+CVE-2025-24161: Google Threat Analysis Group
+CVE-2025-24163: Google Threat Analysis Group
+```
+
+This directory contains an example that demonstrates how these issues were found. On macOS, most of the audio decoding goes through the AudioCodecs module, which then might load other decoders for a specific format. In order for the fuzzing to be as efficient as possible, after opening the file, the harness decodes all audio tracks. This is because tracks can use different encoders and often times interesting tracks (e.g. Apple Positional Audio Codec) are encoded at the end of the file.
+
+Since the audio API requires files to writen on disk with the proper extension (`-file_extension` needed), you need to create a RAM disk and write samples there using the following command for example.
+
+``diskutil erasevolume HFS+ "RAMDisk" `hdiutil attach -nomount ram://524288` ``
+
+Then, you could point the output directory to RAM disk.
+
+To run the audio decoding fuzzer session
+ - Compile Jackalope as described in the main README.
+ - Collect some input video or audio file samples for the format you want to fuzz.
+ - Compile `audiodecode` using `clang -o audiodecode audiodecode.m -framework AVFoundation -framework AudioToolbox -framework Foundation -framework CoreMedia`
+ - By running `audiodecode` binary in a debugger, figure out which module(s) get loaded to handle the decoding of the format you want to fuzz. For example, the decoding of APAC audio with hardware acceleration is done in `AudioCodecs` module. Use the `-instrument_module` flag to collect coverage from this module.
+ - From the build directory, run the fuzzer as (example):
+
+`./Release/fuzzer -mute_child -in in/ -out out/ -nthreads 4 -t 4000 -delivery_dir /Volumes/RAMDisk -file_extension mov -instrument_module AudioCodecs -target_module audiodecode -target_method _fuzz -nargs 1 -iterations 5000 -persist -loop -cmp_coverage -generate_unwind -max_sample_size 2000000  -- ./audiodecode @@`
+
+Other than the already explained flags, `-in`, `-out` and `-t` are fuzzer input, output and timeout, respectively, `-target_module audiodecode -target_method _fuzz -nargs 1 -iterations 5000 -persist -loop` are used to set up persistent fuzzing mode over `fuzz()` function of the harness and `-cmp_coverage` is used to enable the compare coverage.
+
+Other useful flags:
+ - Use `-nthreads <number>` to speeds up your fuzzing session by running on multiple threads in parallel.
+ - Use `-mute_child` to suppress command line output from the decoder.
+ - Use `-target_env DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib` to have the target use guard malloc, which makes detecting memory issues easier. Note that using this will cause slowdowns.

--- a/examples/AudioCodecs/audiodecode.m
+++ b/examples/AudioCodecs/audiodecode.m
@@ -1,0 +1,90 @@
+#include <dlfcn.h>
+#include <stdio.h>
+
+#import <AVFoundation/AVFoundation.h>
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32)
+#define FUZZ_TARGET_MODIFIERS __declspec(dllexport)
+#else
+#define FUZZ_TARGET_MODIFIERS __attribute__((noinline))
+#endif
+
+int FUZZ_TARGET_MODIFIERS fuzz(const char *filename) {
+  @autoreleasepool {
+    NSError *error = nil;
+    NSURL *fileURL = [NSURL fileURLWithPath:[NSString stringWithCString:filename
+                                                               encoding:NSASCIIStringEncoding]];
+    AVAsset *asset = [AVAsset assetWithURL:fileURL];
+    if (asset == nil) return 0;
+
+    AVAssetReader *reader = [[AVAssetReader alloc] initWithAsset:asset error:&error];
+    if (reader == nil) return 0;
+
+    NSArray *tracks = [asset tracksWithMediaType:AVMediaTypeAudio];
+    if (tracks == nil || ([tracks count] == 0)) return 0;
+    for (int i = 0; i < tracks.count; i++) {
+      AVAssetTrack *track = tracks[i];
+      AVAssetReader *assetReader = [AVAssetReader assetReaderWithAsset:asset error:&error];
+      if (error) {
+        NSLog(@"Error creating AVAssetReader: %@", error.localizedDescription);
+        return -1;
+      }
+
+      // Configure the output settings (PCM 16-bit, stereo, 44.1kHz)
+      NSDictionary *outputSettings = @{
+        AVFormatIDKey : @(kAudioFormatLinearPCM),
+        AVSampleRateKey : @44100,
+        AVNumberOfChannelsKey : @2,
+        AVLinearPCMBitDepthKey : @16,
+        AVLinearPCMIsNonInterleaved : @NO,
+        AVLinearPCMIsFloatKey : @NO,
+        AVLinearPCMIsBigEndianKey : @NO
+      };
+
+      AVAssetReaderTrackOutput *trackOutput =
+          [AVAssetReaderTrackOutput assetReaderTrackOutputWithTrack:track
+                                                     outputSettings:outputSettings];
+      [assetReader addOutput:trackOutput];
+
+      if (![assetReader startReading]) {
+        NSLog(@"Error starting asset reader: %@", assetReader.error.localizedDescription);
+        return -1;
+      }
+
+      CMSampleBufferRef sampleBuffer;
+      while ((sampleBuffer = [trackOutput copyNextSampleBuffer])) {
+        CMBlockBufferRef blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer);
+        if (blockBuffer) {
+          size_t length;
+          char *data;
+          OSStatus status = CMBlockBufferGetDataPointer(blockBuffer, 0, NULL, &length, &data);
+          if (status == kCMBlockBufferNoErr) {
+            NSLog(@"Read %zu bytes of audio data", length);
+          } else {
+            NSLog(@"Error accessing block buffer data");
+          }
+        }
+
+        CFRelease(sampleBuffer);
+      }
+
+      // Check the reader status
+      if (assetReader.status == AVAssetReaderStatusCompleted) {
+        NSLog(@"Audio decoding completed successfully.");
+      } else {
+        NSLog(@"Error reading audio: %@", assetReader.error.localizedDescription);
+      }
+    }
+  }
+
+  return 1;
+}
+
+int main(int argc, const char *argv[]) {
+  if (argc < 2) {
+    printf("Usage: %s <filename>\n", argv[0]);
+    return 0;
+  }
+  fuzz(argv[1]);
+  return 0;
+}


### PR DESCRIPTION
Add the fuzzer which was used to discover CVE-2025-24160, CVE-2025-24161 and CVE-2025-24163 in macOS and iOS CoreAudio subsystem as example.