### PR TITLE
Fix CreateMinimizer to use minimization_limit instead of hardcoded 500

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -160,7 +160,7 @@ Mutator* GrammarFuzzer::CreateMutator(int argc, char** argv, ThreadContext* tc) 
 
 Minimizer* GrammarFuzzer::CreateMinimizer(int argc, char** argv, ThreadContext* tc) {
   int minimization_limit = GetIntOption("-grammar_minimization_limit", argc, argv, 500);
-  return new GrammarMinimizer(&grammar, 500);
+  return new GrammarMinimizer(&grammar, minimization_limit);
 }
 
 bool GrammarFuzzer::OutputFilter(Sample* original_sample, Sample* output_sample, ThreadContext* tc) {


### PR DESCRIPTION
In the `CreateMinimizer` method of `GrammarFuzzer`, the `GrammarMinimizer` constructor was using a hardcoded value of 500 for the minimization limit. This change updates it to use the `minimization_limit` variable, which is parsed from the command-line option `-grammar_minimization_limit` with a default of 500. This makes the behavior configurable and consistent with the intended option parsing logic.